### PR TITLE
Fixed a bug that the lb service could not be recreated if deleted. (and add verbose log level option)

### DIFF
--- a/cmd/loxilb-agent/main.go
+++ b/cmd/loxilb-agent/main.go
@@ -73,6 +73,7 @@ func newAgentCommand() *cobra.Command {
 		Long: "The loxilb agent runs on each node.",
 		Run: func(cmd *cobra.Command, args []string) {
 			log.InitLogFileLimits(cmd.Flags())
+			log.InitLogLevel()
 			if err := opts.complete(args); err != nil {
 				klog.Errorf("Failed to options complete. err: %v", err)
 				os.Exit(255)

--- a/cmd/loxilb-agent/main.go
+++ b/cmd/loxilb-agent/main.go
@@ -73,7 +73,7 @@ func newAgentCommand() *cobra.Command {
 		Long: "The loxilb agent runs on each node.",
 		Run: func(cmd *cobra.Command, args []string) {
 			log.InitLogFileLimits(cmd.Flags())
-			log.InitLogLevel()
+			log.InitLogLevel(cmd.Flags())
 			if err := opts.complete(args); err != nil {
 				klog.Errorf("Failed to options complete. err: %v", err)
 				os.Exit(255)

--- a/pkg/api/lb.go
+++ b/pkg/api/lb.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
 )
 
 type EpSelect uint
@@ -128,8 +129,10 @@ func (l *LoadBalancerAPI) Delete(ctx context.Context, lbModel LoxiModel) error {
 	}
 
 	resp := l.client.DELETE(l.resource).SubResource(subresources).Query(queryParam).Body(lbModel).Do(ctx)
-	if resp.err != nil {
-		return resp.err
+	if resp.statusCode != http.StatusOK {
+		if resp.err != nil {
+			return resp.err
+		}
 	}
 
 	return nil

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -130,11 +130,11 @@ func (l *LoxiRequest) Do(ctx context.Context) *LoxiResponse {
 
 	if resp.StatusCode == http.StatusOK {
 		if err := json.Unmarshal(respByte, &result); err != nil {
-			return &LoxiResponse{err: err}
+			return &LoxiResponse{statusCode: resp.StatusCode, err: err}
 		}
 
 		if result.Result != "Success" && !strings.Contains(result.Result, "exist") {
-			return &LoxiResponse{err: errors.New(result.Result)}
+			return &LoxiResponse{statusCode: resp.StatusCode, err: errors.New(result.Result)}
 		}
 	}
 

--- a/pkg/log/logFile.go
+++ b/pkg/log/logFile.go
@@ -35,7 +35,7 @@ const (
 	logFileFlag     = "log_file"
 	maxSizeFlag     = "log_file_max_size"
 	maxNumFlag      = "log_file_max_num"
-
+	verboseFlag     = "v"
 	// Check log file number every 10 mins.
 	logFileCheckInterval = time.Minute * 10
 	// Allowed maximum value for the maximum file size limit.
@@ -46,6 +46,7 @@ var (
 	maxNumArg     = uint16(0)
 	logFileMaxNum = uint16(0)
 	logDir        = ""
+	verbose       = "0"
 
 	executableName = filepath.Base(os.Args[0])
 )
@@ -53,6 +54,7 @@ var (
 func AddFlags(fs *pflag.FlagSet) {
 	fs.Uint16Var(&maxNumArg, maxNumFlag, maxNumArg, "Maximum number of log files per severity level to be kept. Value 0 means unlimited.")
 	fs.StringVar(&logDir, logDirFlag, logDir, "log file directory")
+	fs.StringVar(&verbose, verboseFlag, verbose, "verbose level")
 }
 
 // InitLogFileLimits initializes log file maximum size and maximum number limits based on the

--- a/pkg/log/logLevel.go
+++ b/pkg/log/logLevel.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Netlox Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"flag"
+
+	"k8s.io/klog/v2"
+)
+
+const logVerbosityFlag = "v"
+
+// GetCurrentLogLevel returns the current log verbosity level.
+func GetCurrentLogLevel() string {
+	return flag.Lookup(logVerbosityFlag).Value.String()
+}
+
+// InitLogLevel sets the log verbosity level when init time
+func InitLogLevel() error {
+	level := GetCurrentLogLevel()
+
+	var l klog.Level
+	err := l.Set(level)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Set log level to %s", level)
+	return nil
+}
+
+// SetLogLevel sets the log verbosity level. level must be a string
+// representation of a decimal integer.
+func SetLogLevel(level string) error {
+	oldLevel := GetCurrentLogLevel()
+	if oldLevel == level {
+		return nil
+	}
+
+	var l klog.Level
+	err := l.Set(level)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Changed log level from %s to %s", oldLevel, level)
+	return nil
+
+}

--- a/pkg/log/logLevel.go
+++ b/pkg/log/logLevel.go
@@ -15,7 +15,7 @@
 package log
 
 import (
-	"flag"
+	"github.com/spf13/pflag"
 
 	"k8s.io/klog/v2"
 )
@@ -23,13 +23,13 @@ import (
 const logVerbosityFlag = "v"
 
 // GetCurrentLogLevel returns the current log verbosity level.
-func GetCurrentLogLevel() string {
-	return flag.Lookup(logVerbosityFlag).Value.String()
+func GetCurrentLogLevel(fs *pflag.FlagSet) string {
+	return fs.Lookup(logVerbosityFlag).Value.String()
 }
 
 // InitLogLevel sets the log verbosity level when init time
-func InitLogLevel() error {
-	level := GetCurrentLogLevel()
+func InitLogLevel(fs *pflag.FlagSet) error {
+	level := GetCurrentLogLevel(fs)
 
 	var l klog.Level
 	err := l.Set(level)
@@ -39,22 +39,4 @@ func InitLogLevel() error {
 
 	klog.Infof("Set log level to %s", level)
 	return nil
-}
-
-// SetLogLevel sets the log verbosity level. level must be a string
-// representation of a decimal integer.
-func SetLogLevel(level string) error {
-	oldLevel := GetCurrentLogLevel()
-	if oldLevel == level {
-		return nil
-	}
-
-	var l klog.Level
-	err := l.Set(level)
-	if err != nil {
-		return err
-	}
-	klog.Infof("Changed log level from %s to %s", oldLevel, level)
-	return nil
-
 }


### PR DESCRIPTION
When deleting the k8s LoadBalancer service, there was a case where kube-loxilb continued to send the delete API to loxilb even though loxilb's rules were already deleted. In this case, the corresponding error occurs.

The reason this error occurs is due to the problem of duplication of lbEntry of kube-loxilb.

So I removed the duplication of lbEntry, and modified to check the http status code.

