### PR TITLE
Change kube-loxilb labels and selector names

### DIFF
--- a/manifest/kube-loxilb-cidrv6.yaml
+++ b/manifest/kube-loxilb-cidrv6.yaml
@@ -80,16 +80,16 @@ metadata:
   name: kube-loxilb
   namespace: kube-system
   labels:
-    app: loxilb
+    app: kube-loxilb-app
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: loxilb
+      app: kube-loxilb-app
   template:
     metadata:
       labels:
-        app: loxilb
+        app: kube-loxilb-app
     spec:
       hostNetwork: true
       tolerations:

--- a/manifest/kube-loxilb-secondaryIPs.yaml
+++ b/manifest/kube-loxilb-secondaryIPs.yaml
@@ -80,16 +80,16 @@ metadata:
   name: kube-loxilb
   namespace: kube-system
   labels:
-    app: loxilb
+    app: kube-loxilb-app
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: loxilb
+      app: kube-loxilb-app
   template:
     metadata:
       labels:
-        app: loxilb
+        app: kube-loxilb-app
     spec:
       hostNetwork: true
       tolerations:

--- a/manifest/kube-loxilb.yaml
+++ b/manifest/kube-loxilb.yaml
@@ -80,16 +80,16 @@ metadata:
   name: kube-loxilb
   namespace: kube-system
   labels:
-    app: loxilb
+    app: kube-loxilb-app
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: loxilb
+      app: kube-loxilb-app
   template:
     metadata:
       labels:
-        app: loxilb
+        app: kube-loxilb-app
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
Currently, kube-loxilb has labels and selectors that can be matching some other labels and selectors in the loxilb stack. For example, loxilb deployments(the load balancer) or the nginx service that is present in the documentation(https://www.loxilb.io/post/loxilb-load-balancer-setup-on-eks). This would lead into some networking issues, due to the allocation of two endpoints for the same service since you have two deployments, referring to the same service via labels and selectors. This PR changes the kube-loxilb labels to be more unique to not be conflicting with other resources in the cluster where loxilb components are deployed 