### PR TITLE
Check http statusCode when delete loxilb's LB rule

### DIFF
--- a/pkg/api/lb.go
+++ b/pkg/api/lb.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
 )
 
 type EpSelect uint
@@ -128,8 +129,10 @@ func (l *LoadBalancerAPI) Delete(ctx context.Context, lbModel LoxiModel) error {
 	}
 
 	resp := l.client.DELETE(l.resource).SubResource(subresources).Query(queryParam).Body(lbModel).Do(ctx)
-	if resp.err != nil {
-		return resp.err
+	if resp.statusCode != http.StatusOK {
+		if resp.err != nil {
+			return resp.err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If kube-loxilb fails to create an LB, kube-loxilb attempts to clean up all LB information created so far.
At this time, loxilb returns an error (no rules) with http Status 200 if there is no corresponding LB rule.

Currently, kube-loxilb does not check the status code, so it judges this as a deletion failure.
Therefore, the cleanup also fails.
This causes a state in which external IPs cannot be assigned to services because the IP Pool is not organized.

To prevent this issue I updated the code.