### PR TITLE
add loxilb.io/secondaryIPs annotation

### DIFF
--- a/cmd/loxilb-agent/agent.go
+++ b/cmd/loxilb-agent/agent.go
@@ -107,7 +107,7 @@ func run(o *Options) error {
 	var sipPools []*ippool.IPPool
 	if len(o.config.ExternalSecondaryCIDRs) != 0 {
 
-		if len(o.config.ExternalSecondaryCIDRs) > 4 {
+		if len(o.config.ExternalSecondaryCIDRs) >= loadbalancer.MaxExternalSecondaryIPsNum {
 			return fmt.Errorf("externalSecondaryCIDR %s config is invalid", o.config.ExternalSecondaryCIDRs)
 		}
 

--- a/pkg/lb.go
+++ b/pkg/lb.go
@@ -1,5 +1,0 @@
-package pkg
-
-import (
-	_ "net/http"
-)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,0 +1,13 @@
+package util
+
+func SliceEqual[E comparable](s1, s2 []E) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
It can use like:

```apiVersion: v1
kind: Service
metadata:
  name: tcp-lb-default
  annotations:
    loxilb.io/lbmode: "default"
    loxilb.io/secondaryIPs: "123.123.123.123,2.2.2.2"
spec:
  loadBalancerClass: loxilb.io/loxilb
  selector:
    what: tcp-default-test
  ports:
    - port: 55002
      targetPort: 80
      protocol: SCTP
  type: LoadBalancer
```