### PR TITLE
support external loxilb & in-cluster pod peering 

### DIFF
--- a/cmd/loxilb-agent/agent.go
+++ b/cmd/loxilb-agent/agent.go
@@ -182,6 +182,7 @@ func run(o *Options) error {
 		if len(networkConfig.LoxilbURLs) <= 0 {
 			lbManager.DiscoverLoxiLBServices(loxiLBLiveCh, loxiLBPurgeCh)
 		}
+		lbManager.DiscoverLoxiLBPeerServices(loxiLBLiveCh, loxiLBPurgeCh)
 
 		if networkConfig.SetRoles != "" {
 			lbManager.SelectLoxiLBRoles(true, loxiLBSelMasterEvent)

--- a/pkg/agent/manager/loadbalancer/loadbalancer.go
+++ b/pkg/agent/manager/loadbalancer/loadbalancer.go
@@ -1278,9 +1278,11 @@ func (m *Manager) DiscoverLoxiLBServices(loxiLBAliveCh chan *api.LoxiClient, lox
 		}
 	}
 	m.LoxiClients = tmp
+}
 
+func (m *Manager) DiscoverLoxiLBPeerServices(loxiLBAliveCh chan *api.LoxiClient, loxiLBPurgeCh chan *api.LoxiClient) {
 	var tmploxilbPeerClients []*api.LoxiClient
-	ips, err = k8s.GetServiceEndPoints(m.kubeClient, "loxilb-peer-service", "kube-system")
+	ips, err := k8s.GetServiceEndPoints(m.kubeClient, "loxilb-peer-service", "kube-system")
 	klog.Infof("loxilb-peer-service end-points:  %v", ips)
 	if err != nil {
 		ips = []net.IP{}


### PR DESCRIPTION
kube-loxilb.yaml example:

args:
        - --loxiURL=http://192.168.80.9:11111
        - --externalCIDR=123.123.123.1/24
        - --setBGP=64512
        - --listenBGPPort=1791
        - --setRoles=0.0.0.0
