### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TAG?=latest
 
 build:
 	@mkdir -p ./bin
+	go mod tidy
 	go build -o ./bin/${bin} -ldflags="-X 'main.BuildInfo=${shell date '+%Y_%m_%d'}-${shell git branch --show-current}-$(shell git show --pretty=format:%h --no-patch)' -X 'main.Version=${shell git describe --tags --abbrev=0}'" ./cmd/loxilb-agent
 
 clean:


### PR DESCRIPTION
Because the golang module version of github action is too low,  the build will fail without go mod tidy.