### PR TITLE
add new args for gatewayAPI

### DIFF
--- a/cmd/loxilb-agent/config.go
+++ b/cmd/loxilb-agent/config.go
@@ -38,6 +38,8 @@ type AgentConfig struct {
 	NodePortServiceVirtIP string `yaml:"nodePortServiceVirtIP,omitempty"`
 	// support LoadBalancerClass
 	LoxilbLoadBalancerClass string `yaml:"loxilbLoadBalancerClass,omitempty"`
+	// enable Gateway API
+	EnableGatewayAPI bool `yaml:"gatewayAPI"`
 	// support GatewayClass manager name
 	LoxilbGatewayClass string `yaml:"loxilbGatewayClass,omitempty"`
 	// support LoadBalancer external IP

--- a/cmd/loxilb-agent/options.go
+++ b/cmd/loxilb-agent/options.go
@@ -60,6 +60,7 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.config.ExternalCIDR6, "externalCIDR6", o.config.ExternalCIDR6, "External CIDR6 Range")
 	fs.StringVar(&secondaryCIDRs6, "externalSecondaryCIDRs6", secondaryCIDRs6, "External Secondary CIDR6 Range(s)")
 	fs.StringVar(&o.config.LoxilbLoadBalancerClass, "loxilbLoadBalancerClass", o.config.LoxilbLoadBalancerClass, "Load-Balancer Class Name")
+	fs.BoolVar(&o.config.EnableGatewayAPI, "gatewayAPI", false, "Enable gateway API managers")
 	fs.StringVar(&o.config.LoxilbGatewayClass, "loxilbGatewayClass", o.config.LoxilbGatewayClass, "GatewayClass manager Name")
 	fs.Uint16Var(&o.config.SetBGP, "setBGP", o.config.SetBGP, "Use BGP routing")
 	fs.Uint16Var(&o.config.ListenBGPPort, "listenBGPPort", o.config.ListenBGPPort, "Custom BGP listen port")
@@ -175,9 +176,11 @@ func (o *Options) validate(args []string) error {
 		}
 	}
 
-	if o.config.LoxilbGatewayClass != "" {
-		if ok := strings.Contains(o.config.LoxilbGatewayClass, "/"); !ok {
-			return fmt.Errorf("LoxilbGatewayClass must be a label-style identifier")
+	if o.config.EnableGatewayAPI {
+		if o.config.LoxilbGatewayClass != "" {
+			if ok := strings.Contains(o.config.LoxilbGatewayClass, "/"); !ok {
+				return fmt.Errorf("LoxilbGatewayClass must be a label-style identifier")
+			}
 		}
 	}
 

--- a/manifest/gateway-api/kube-loxilb.yaml
+++ b/manifest/gateway-api/kube-loxilb.yaml
@@ -126,6 +126,7 @@ spec:
         - --setBGP=64512
         - --listenBGPPort=1791
         - --setRoles=0.0.0.0
+        - --gatewayAPI
         #- --extBGPPeers=50.50.50.1:65101,51.51.51.1:65102
         #- --setLBMode=1
         #- --config=/opt/loxilb/agent/kube-loxilb.conf


### PR DESCRIPTION
If you want to enable gateway API managers, add --gatewayAPI to kube-loxilb's args

args:
        #- --loxiURL=http://12.12.12.1:11111,http://14.14.14.1:11111
        - --externalCIDR=123.123.123.1/24
        #- --externalSecondaryCIDRs=124.124.124.1/24,125.125.125.1/24
        #- --monitor
        - --setBGP=64512
        - --listenBGPPort=1791
        - --setRoles=0.0.0.0
        - --gatewayAPI
        #- --extBGPPeers=50.50.50.1:65101,51.51.51.1:65102
        #- --setLBMode=1
        #- --config=/opt/loxilb/agent/kube-loxilb.conf