### PR TITLE
fix: remane LBModeNotDefault to LBModeDefault

### DIFF
--- a/pkg/agent/manager/loadbalancer/loadbalancer.go
+++ b/pkg/agent/manager/loadbalancer/loadbalancer.go
@@ -577,7 +577,7 @@ func (m *Manager) addLoadBalancer(svc *corev1.Service) error {
 		} else if lbm == "onearm" {
 			lbMode = api.LBModeOneArm
 		} else if lbm == "default" {
-			lbMode = api.LBModeNotDefault
+			lbMode = api.LBModeDefault
 		} else {
 			lbMode = api.LBModeNotSupported
 		}

--- a/pkg/api/lb.go
+++ b/pkg/api/lb.go
@@ -29,7 +29,7 @@ type LbMode int32
 
 const (
 	LBModeNotSupported = iota - 1
-	LBModeNotDefault
+	LBModeDefault
 	LBModeOneArm
 	LBModeFullNat
 	LBModeDsr


### PR DESCRIPTION
Hi @nik-netlox @TrekkieCoder 
This pull request includes changes to the load balancer mode handling in the `pkg/agent/manager/loadbalancer` package. The main changes involve renaming and correcting the load balancer mode constants to ensure the default mode is set correctly.

Changes to load balancer mode handling:

* [`pkg/agent/manager/loadbalancer/loadbalancer.go`](diffhunk://#diff-5203b7ecb5ec44e56f65b9d24bd5ddb719f56468dfda5a8309e1aa41e0d667dfL580-R580): Corrected the load balancer mode assignment by changing `LBModeNotDefault` to `LBModeDefault` in the `addLoadBalancer` method.
* [`pkg/api/lb.go`](diffhunk://#diff-e03c75eee690fec34814139040922d80829dfab4e21c367bdaaa0256c15a1a3aL32-R32): Renamed the `LBModeNotDefault` constant to `LBModeDefault` to reflect the correct load balancer mode.