### PR TITLE
fixed zone instance name

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -52,11 +52,7 @@ type LoxiClient struct {
 
 // GenZoneInstName generate zone instance name
 func GenZoneInstName(zone string, id int) string {
-	instName := "default"
-	if id != 0 {
-		instName = fmt.Sprintf("%s-%s%d", zone, "inst", id)
-	}
-	return instName
+	return fmt.Sprintf("%s-%s%d", zone, "inst", id)
 }
 
 // apiServer is string. what format? http://10.0.0.1 or 10.0.0.1


### PR DESCRIPTION
Fixes problem where the incorrect instance-name is set. 

`zone` in my setup is set to `crc` and `numZoneInstances` to `2`

Instance number `0` is always called `default`, however it should be called `crc-inst0`. 

Before fix:

```
 loxicmd get lb -owide
|     EXT IP     | SEC IPS | SOURCES | HOST | PORT | PROTO |                   NAME                    | MARK | SEL |  MODE  |    ENDPOINT    | EPORT | WEIGHT | STATE | COUNTERS |
|----------------|---------|---------|------|------|-------|-------------------------------------------|------|-----|--------|----------------|-------|--------|-------|----------|
| 192.168.120.20 |         |         |      |  443 | tcp   | openshift-console_console-ext:default     |    0 | rr  | onearm | 192.168.126.11 | 31203 |      1 | -     | 0:0      |
| 192.168.120.21 |         |         |      |  443 | tcp   | openshift-console_console-ext-2:crc-inst1 |    0 | rr  | onearm | 192.168.126.11 | 30176 |      1 | -     | 0:0      |
| 192.168.120.22 |         |         |      |  443 | tcp   | openshift-console_console-ext-3:default   |    0 | rr  | onearm | 192.168.126.11 | 30901 |      1 | -     | 0:0      |
| 192.168.120.23 |         |         |      |  443 | tcp   | openshift-console_console-ext-4:crc-inst1 |    0 | rr  | onearm | 192.168.126.11 | 30559 |      1 | -     | 0:0      |
```

After fix:

```
loxicmd get lb -owide
|     EXT IP     | SEC IPS | SOURCES | HOST | PORT | PROTO |                   NAME                    | MARK | SEL |  MODE  |    ENDPOINT    | EPORT | WEIGHT | STATE | COUNTERS |
|----------------|---------|---------|------|------|-------|-------------------------------------------|------|-----|--------|----------------|-------|--------|-------|----------|
| 192.168.120.20 |         |         |      |  443 | tcp   | openshift-console_console-ext:crc-inst0   |    0 | rr  | onearm | 192.168.126.11 | 32196 |      1 | -     | 24:2619  |
| 192.168.120.21 |         |         |      |  443 | tcp   | openshift-console_console-ext-2:crc-inst1 |    0 | rr  | onearm | 192.168.126.11 | 31514 |      1 | -     | 0:0      |
| 192.168.120.22 |         |         |      |  443 | tcp   | openshift-console_console-ext-3:crc-inst0 |    0 | rr  | onearm | 192.168.126.11 | 30419 |      1 | -     | 24:2619  |
| 192.168.120.23 |         |         |      |  443 | tcp   | openshift-console_console-ext-4:crc-inst1 |    0 | rr  | onearm | 192.168.126.11 | 32609 |      1 | -     | 0:0      |

```