### PR TITLE
Added annotation to enable egress to support Multus.

### DIFF
--- a/pkg/agent/manager/loadbalancer/loadbalancer.go
+++ b/pkg/agent/manager/loadbalancer/loadbalancer.go
@@ -378,7 +378,7 @@ func (m *Manager) syncLoadBalancer(lb LbCacheKey) error {
 		klog.V(4).Infof("Finished syncing LoadBalancer service %s. (%v)", lb.Name, time.Since(startTime))
 	}()
 
-	//m.compareLoxiLBToK8sService()
+	m.compareLoxiLBToK8sService()
 
 	svcNs := lb.Namespace
 	svcName := lb.Name
@@ -1430,8 +1430,9 @@ func (m *Manager) getLocalEndpoints(svc *corev1.Service, addrType string) ([]str
 		return nil, errors.New("not found multus annotations")
 	}
 	netList := strings.Split(netListStr, ",")
+	selectorLabelStr := labels.Set(svc.Spec.Selector).String()
 
-	return k8s.GetMultusEndpoints(m.kubeClient, svc, netList, addrType)
+	return k8s.GetMultusEndpoints(m.kubeClient, svc.Namespace, selectorLabelStr, netList, addrType)
 }
 
 // getMultusEndpoints returns the IP list of the Pods connected to the multus network.
@@ -1441,8 +1442,8 @@ func (m *Manager) getMultusEndpoints(svc *corev1.Service, addrType string) ([]st
 		return nil, errors.New("not found multus annotations")
 	}
 	netList := strings.Split(netListStr, ",")
-
-	return k8s.GetMultusEndpoints(m.kubeClient, svc, netList, addrType)
+	selectorLabelStr := labels.Set(svc.Spec.Selector).String()
+	return k8s.GetMultusEndpoints(m.kubeClient, svc.Namespace, selectorLabelStr, netList, addrType)
 }
 
 func (m *Manager) getNodeAddress(node corev1.Node, addrType string) (string, error) {

--- a/pkg/k8s/multus.go
+++ b/pkg/k8s/multus.go
@@ -21,12 +21,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	clientset "k8s.io/client-go/kubernetes"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 type dnsIf interface{}
@@ -83,14 +82,13 @@ func GetMultusNetworkStatus(ns, name string) (networkStatus, error) {
 	return networkStatus{}, fmt.Errorf("not found %s network", name)
 }
 
-func GetMultusEndpoints(kubeClient clientset.Interface, svc *corev1.Service, netList []string, addrType string) ([]string, error) {
+func GetMultusEndpoints(kubeClient clientset.Interface, svcNs, selectorLabelStr string, netList []string, addrType string) ([]string, error) {
 	var epList []string
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	selectorLabelStr := labels.Set(svc.Spec.Selector).String()
-	podList, err := kubeClient.CoreV1().Pods(svc.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selectorLabelStr})
+	podList, err := kubeClient.CoreV1().Pods(svcNs).List(ctx, metav1.ListOptions{LabelSelector: selectorLabelStr})
 	if err != nil {
 		return epList, err
 	}


### PR DESCRIPTION
There are cases in egress where a selector is used instead of directly specifying IP addresses.
When using a selector, it was previously not possible to apply egress to a Multus network.
This pull request adds an annotation that allows specifying the Multus network when a selector is used.

The annotation can be used in egress the same way as in the loadbalancer, as shown below.


```
annotations:
    loxilb.io/multus-nets : macvlan1,macvlan2
```