### PR TITLE
add noZoneName option

### DIFF
--- a/cmd/loxilb-agent/config.go
+++ b/cmd/loxilb-agent/config.go
@@ -81,4 +81,6 @@ type AgentConfig struct {
 	UsePodNetwork bool `yaml:"usePodNetwork,omitempty"`
 	// If true, direct traffic forwarding from the LoxiLB to external endpoints
 	UseExternalEndpoint bool `yaml:"useExternalEndpoint,omitempty"`
+	// If true, do not use the automatically appended zone name in the external IP of the Kubernetes service.
+	NoZoneName bool `yaml:"noZoneName,omitempty"`
 }

--- a/cmd/loxilb-agent/options.go
+++ b/cmd/loxilb-agent/options.go
@@ -79,6 +79,7 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.config.NumZoneInst, "numZoneInstances", o.config.NumZoneInst, "Number of HA instances per zone")
 	fs.BoolVar(&o.config.UsePodNetwork, "usePodNetwork", o.config.UsePodNetwork, "direct traffic forwarding from the LoxiLB to pods without NodePort")
 	fs.BoolVar(&o.config.UseExternalEndpoint, "useExternalEndpoint", o.config.UseExternalEndpoint, "direct traffic forwarding from the LoxiLB to external endpoints")
+	fs.BoolVar(&o.config.NoZoneName, "noZoneName", o.config.NoZoneName, "Do not use the automatically appended zone name in the external IP of the Kubernetes service. (like llb)")
 }
 
 // complete completes all the required optionst
@@ -321,7 +322,11 @@ func (o *Options) setDefaults() {
 		o.config.ListenBGPPort = 179
 	}
 	if o.config.Zone == "" {
-		o.config.Zone = "llb"
+		if o.config.NoZoneName {
+			o.config.Zone = ""
+		} else {
+			o.config.Zone = "llb"
+		}
 	}
 	if o.config.NumZoneInst == 0 {
 		o.config.NumZoneInst = 1

--- a/pkg/agent/manager/loadbalancer/loadbalancer.go
+++ b/pkg/agent/manager/loadbalancer/loadbalancer.go
@@ -214,7 +214,11 @@ func GenSPKey(IPString string, Port uint16, Protocol string) string {
 
 func (m *Manager) genExtIPName(ipStr string) []string {
 	var hosts []string
-	prefix := m.networkConfig.Zone + "-"
+
+	prefix := ""
+	if m.networkConfig.Zone != "" {
+		prefix = m.networkConfig.Zone + "-"
+	}
 
 	IP := net.ParseIP(ipStr)
 	if IP != nil {

--- a/pkg/api/lb.go
+++ b/pkg/api/lb.go
@@ -82,7 +82,7 @@ type LoadBalancerService struct {
 	BGP          bool     `json:"BGP" options:"bgp"`
 	Monitor      bool     `json:"Monitor"`
 	Timeout      uint32   `json:"inactiveTimeOut"`
-	Block        uint16   `json:"block" options:"block"`
+	Block        uint32   `json:"block" options:"block"`
 	Managed      bool     `json:"managed,omitempty"`
 	ProbeType    string   `json:"probetype"`
 	ProbePort    uint16   `json:"probeport"`


### PR DESCRIPTION
Added the `--noZoneName` option to remove the `llb-` tag prefix from the external IP.
You can add it to the `args` of kube-loxilb as shown in the example below.

```
args:
        - --cidrPools=defaultPool=192.168.50.247/32
        - --setRoles=0.0.0.0
        - --setLBMode=1
        - --noZoneName
```