### PR TITLE
ci: build each arch on a native runner and merge by digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,78 +8,139 @@ on:
         description: 'Tag Name'
         required: true
         default: 'latest'
+
+env:
+  IMAGE: ghcr.io/loxilb-io/kube-loxilb
+
 jobs:
+  # Forks only verify that the image still builds.
+  build-check:
+    if: github.repository != 'loxilb-io/kube-loxilb'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+
+  # One native runner per architecture. Nothing is tagged here: each job pushes
+  # a single-platform image addressed only by digest, and hands the digest to
+  # the merge job as an artifact.
   build:
-    runs-on: ubuntu-latest
-    name: docker-ci
+    if: github.repository == 'loxilb-io/kube-loxilb'
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout Branch
+        if: github.event.inputs.tagName != ''
+        run: |
+          git fetch --all --tags
+          git checkout ${{ github.event.inputs.tagName }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: TAG=${{ github.event.inputs.tagName }}
+          provenance: false
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Slugify platform
+        id: slug
+        run: echo "value=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.slug.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assembles the per-arch digests into one manifest list and publishes the tag.
+  # This is the only step that makes anything user-visible, so a failed arch
+  # build never leaves a half-updated tag behind.
+  merge:
+    if: github.repository == 'loxilb-io/kube-loxilb'
+    needs: [build]
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v2
-      with:
-          submodules: recursive
+      - uses: actions/checkout@v4
 
-    - name : Checkout Branch
-      if:  github.event.inputs.tagName != ''
-      run: |
-          git fetch --all --tags
-          git checkout ${{ github.event.inputs.tagName }}
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
 
-    # Setup hardware emulator using QEMU
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    # Setup Docker Buildx for multi-arch images
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      - name: Resolve tag
+        id: tag
+        run: echo "value=${TAG:-latest}" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ github.event.inputs.tagName }}
 
-    - name: Build Check
-      if: |
-          github.repository != 'loxilb-io/kube-loxilb'
-      uses: docker/build-push-action@v4
-      with:
-        context: .
-        platforms: linux/amd64, linux/arm64
-        push: false
-        tags: ghcr.io/loxilb-io/kube-loxilb:latest
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE}:${{ steps.tag.outputs.value }}" \
+            $(printf "${IMAGE}@sha256:%s " *)
 
-    - name: Build and push to latest
-      if: |
-          github.repository == 'loxilb-io/kube-loxilb'
-          &&  github.event.inputs.tagName == ''
-      uses: docker/build-push-action@v4
-      with:
-        context: .
-        platforms: linux/amd64, linux/arm64
-        push: true
-        tags: ghcr.io/loxilb-io/kube-loxilb:latest
+      - name: Inspect
+        run: docker buildx imagetools inspect "${IMAGE}:${{ steps.tag.outputs.value }}"
 
-    - name: Build and push to given tag
-      if: |
-          github.repository == 'loxilb-io/kube-loxilb'
-          &&  github.event.inputs.tagName != ''
-      uses: docker/build-push-action@v4
-      with:
-        context: .
-        platforms: linux/amd64, linux/arm64
-        push: true
-        build-args: TAG=${{ github.event.inputs.tagName }}
-        tags: ghcr.io/loxilb-io/kube-loxilb:${{ github.event.inputs.tagName }}
-
-    # Re-pushing :latest orphans the previous index and its per-platform child
-    # manifests. The script keeps every child that a tagged index still points
-    # at, so multi-arch tags stay intact.
-    - name: Cleanup untagged kube-loxilb versions
-      if: github.repository == 'loxilb-io/kube-loxilb'
-      continue-on-error: true
-      env:
-        GH_TOKEN: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
-      run: .github/scripts/cleanup-untagged-packages.sh loxilb-io kube-loxilb
+      # push-by-digest leaves the per-arch manifests untagged, and the tag this
+      # run replaced orphans its own children. Reclaim whatever is no longer
+      # referenced by a tagged index.
+      - name: Cleanup untagged kube-loxilb versions
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
+        run: .github/scripts/cleanup-untagged-packages.sh loxilb-io kube-loxilb


### PR DESCRIPTION
> Rebased onto main after #266 merged. The conflict was in `docker-publish.yml` only: #266 added the cleanup step to the old single-job layout while this PR rewrites the file. Resolved in favour of this PR's layout, which carries both of #266's additions to that file — the `permissions` block and the cleanup step, now at the end of the `merge` job.

## Motivation

`docker-publish.yml` builds both platforms in a single buildx call on an amd64 runner:

```yaml
platforms: linux/amd64, linux/arm64
```

The [Dockerfile](../blob/main/Dockerfile) is multi-stage and runs `make build` inside `golang:1.23-alpine`, so the arm64 half compiles the entire Go binary under QEMU emulation. That is the slowest part of the pipeline and it is pure emulation overhead.

## Change

A matrix of native runners builds both arches in parallel. **Neither build job publishes a tag** — each pushes a single-platform image addressed only by digest and hands that digest to the merge job as an artifact:

```yaml
      - uses: docker/build-push-action@v6
        id: build
        with:
          platforms: ${{ matrix.platform }}
          provenance: false
          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true

      - run: |
          digest='${{ steps.build.outputs.digest }}'
          mkdir -p /tmp/digests && touch "/tmp/digests/${digest#sha256:}"
```

The merge job assembles them:

```yaml
      - working-directory: /tmp/digests
        run: |
          docker buildx imagetools create \
            -t "${IMAGE}:${{ steps.tag.outputs.value }}" \
            $(printf "${IMAGE}@sha256:%s " *)
```

This is the pattern from Docker's own multi-platform CI docs. No `<tag>-amd64` / `<tag>-arm64` intermediate tags are created.

## What this buys

- arm64 builds natively instead of under QEMU.
- The two arches build concurrently rather than sequentially.
- The tag is written exactly once, in one place, at the end. A failed arch build cannot leave a half-updated tag behind.
- `provenance: false` drops the two attestation manifests each build was adding to the package.

## What this does **not** do

It does not reduce untagged versions in GHCR. `push-by-digest` creates them by design, and the merged index keeps its per-platform children untagged. #266 is still what reclaims them — and it composes well here, since it also picks up digests orphaned by a merge job that never ran.

## Also in this PR

- Pinned actions refreshed: `checkout@v4`, `setup-buildx-action@v3`, `login-action@v3`, `build-push-action@v6`.
- QEMU setup dropped — no longer needed with native runners.
- The fork-side "Build Check" becomes its own `build-check` job guarded by `github.repository != 'loxilb-io/kube-loxilb'`, instead of an `if:` on a step inside the publish job.
- Explicit `permissions: {contents: read, packages: write}` on the publishing jobs.

## Reviewer note

`ubuntu-24.04-arm` is a GitHub-hosted runner, free for public repositories. If it is unavailable under the loxilb-io org settings, change that one matrix entry back to `ubuntu-24.04` and re-add `docker/setup-qemu-action` — the rest of the structure is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
